### PR TITLE
Coveralls support

### DIFF
--- a/travis_setup.php
+++ b/travis_setup.php
@@ -188,7 +188,9 @@ if($coreBranch == 'master' || version_compare($coreBranch, '3.0') >= 0) {
 }
 
 //coveralls
-$composer['require']['satooshi/php-coveralls'] = '*';
+if(getenv('COVERALLS')){
+	$composer['require']['satooshi/php-coveralls'] = '*';
+}
 
 $composerStr = json_encode($composer);
 


### PR DESCRIPTION
I have added support for coveralls to the omnipay module (via the [php-coveralls](https://github.com/satooshi/php-coveralls) library), however it required a change to the generated composer file, as specified in this pull request. I'm not sure if it is desirable to have this addition to silverstripe travis support.

I did originally try doing the extra composer require with a extra travis command, but i got the message: [Package "satooshi/php-coveralls" listed for update is not installed. Ignoring.](https://travis-ci.org/burnbright/silverstripe-omnipay/builds/18163573#L106)
