### PR TITLE
API Enable use of custom repositories for testing

### DIFF
--- a/travis_setup.php
+++ b/travis_setup.php
@@ -131,7 +131,15 @@ $package = array_replace_recursive($package, array(
 
 // Generate a custom composer file.
 $composer = array(
-	'repositories' => array(array('type' => 'package', 'package' => $package)),
+	'repositories' => array_merge(
+		// Require this module via a direct package
+		array(array(
+			'type' => 'package',
+			'package' => $package
+		)),
+		// Promote any custom repositories to the top level
+		isset($package['repositories']) ? $package['repositories'] : array()
+	),
 	'require' => array_merge(
 		isset($package['require']) ? $package['require'] : array(),
 		array($package['name'] => $moduleBranchComposer)


### PR DESCRIPTION
This supports not only dependencies that are not on packagist, but also allows to run test runs against forked versions of framework.
