### PR TITLE
Remove hard-coded GithHub token

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,6 @@ env:
     - ...
 ```
 
-Note that this script comes with a default token. Since rate limitations on this token globally apply 
-to the user it is connected to, we ask to you be fair and configure your own tokens.
-
 ## Behat and Selenium
 
 The scripts also allow behaviour testing through [Behat](http://behat.org).

--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ env:
     - ...
 ```
 
+Alternatively you can add the Token through the Travis CI web interface for your repo under the "settings" area. 
+
 ## Behat and Selenium
 
 The scripts also allow behaviour testing through [Behat](http://behat.org).

--- a/travis_setup.php
+++ b/travis_setup.php
@@ -20,15 +20,6 @@ if (php_sapi_name() != 'cli') {
 	exit;
 }
 
-$defaults = array(
-	// Readonly token for 'silverstripe-issues' user to increase our rate limitation.
-	// Please be fair and define your own token if using for own projects.
-	'GITHUB_API_TOKEN' => '2434108664388ca0199319b98a6068af8e5dc547'
-);
-
-/**
- * 1. Check and parse command line options
- */
 $opts = getopt('', array(
 	'source:',      // Required: Path to the module root directory
 	'target:',      // Required: Path to where the environment will be built
@@ -87,7 +78,6 @@ printf("  * PHP:     %s\n\n", trim(`php --version`));
  * 4. Set up Github API token for higher rate limits (optional)
  * See http://blog.simplytestable.com/creating-and-using-a-github-oauth-token-with-travis-and-composer/
  */
-if(!getenv('GITHUB_API_TOKEN')) putenv('GITHUB_API_TOKEN=' . $defaults['GITHUB_API_TOKEN']);
 if(
 	getenv('GITHUB_API_TOKEN')
 	// Defaults to unencrypted tokens, so we don't need to exclude pull requests

--- a/travis_setup.php
+++ b/travis_setup.php
@@ -142,7 +142,7 @@ if(file_exists("$targetPath/composer.lock")) {
 	run("rm $targetPath/composer.lock");
 }
 
-run("cd ~ && composer install --no-ansi $installType -d $targetPath");
+run("cd ~ && composer install --verbose --optimize-autoloader --no-interaction --no-progress --no-suggest --no-ansi $installType -d $targetPath");
 
 /**
  * 8. Installer doesn't work out of the box without cms - delete the Page class if its not required


### PR DESCRIPTION
Exposing a github token publicly should be avoided.

Having researched this problem it appears GitHub removed API limits on fetching archives in March this year and therefore a GitHub API token *should* be optional.

Alternatively using `--prefer-source` could provide a workaround (https://github.com/composer/composer/issues/1314) though with mixed results for some.