### PR TITLE
Use prefer-stable for dependencies

### DIFF
--- a/src/ComposerGenerator.php
+++ b/src/ComposerGenerator.php
@@ -274,6 +274,7 @@ class ComposerGenerator {
 				'phpunit/phpunit' => '^3 || ^4 || ^5' // Default phpunit version if none specified
 			),
 			'minimum-stability' => 'dev',
+			'prefer-stable' => true,
 			'config' => array(
 				'notify-on-install' => false,
 				'process-timeout' => 600, // double default timeout, github archive downloads tend to be slow

--- a/tests/ComposerGeneratorTest.php
+++ b/tests/ComposerGeneratorTest.php
@@ -391,6 +391,7 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 				'phpunit/phpunit' => '~3.7'
 			),
 			'minimum-stability' => 'dev',
+			'prefer-stable' => true,
 			'config' => array(
 				'notify-on-install' => '',
 				'process-timeout' => '600'
@@ -675,6 +676,7 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 				'phpunit/phpunit' => '^3 || ^4 || ^5'
 			),
 			'minimum-stability' => 'dev',
+			'prefer-stable' => true,
 			'config' => array(
 				'notify-on-install' => false,
 				'process-timeout' => 600


### PR DESCRIPTION
N.b. it’s 5:30 on Friday and I’ve not thought through implications of this, but it solves the Behat issues in 3.x builds:

https://travis-ci.org/silverstripe/silverstripe-framework/jobs/306861877#L503

`mink-selenium2-driver` requires `"instaclick/php-webdriver": "~1.1"`, but we were getting `dev-master` (presumably because of the missing `prefer-stable`, and that their branch alias needs updating - https://github.com/instaclick/php-webdriver/issues/82).